### PR TITLE
feat: update CDP button detection to match Antigravity DOM (v0.0.24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "antigravity-plus",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publisher": "ImL1s",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
### Changes
- **Updated Button Detection Script**: Use \.bg-ide-button-background\ selector for Antigravity
- **Added isAcceptButton()**: Text pattern matching for accept/run/retry/apply/execute/confirm/allow
- **Added Reject Patterns**: Skip buttons with skip/reject/cancel/close/refine in text
- **Version Bump**: 0.0.24

### Reference
Based on analysis of MunKhin/auto-accept-agent implementation.

### Verification
- Compilation: ✅
- Lint: 0 errors
- Unit Tests: 92 passing